### PR TITLE
merge 2.7 Eternity Mode change:

### DIFF
--- a/Content/Items/EModeItemBalance.cs
+++ b/Content/Items/EModeItemBalance.cs
@@ -180,6 +180,11 @@ namespace FargowiltasSouls.Content.Items
                         return EModeChange.None;
                     }
 
+                case ItemID.CrossNecklace:
+                case ItemID.StarVeil:
+                    balanceTextKeys = new string[] { "CrossNecklaceNerf" };
+                    return EModeChange.Nerf;
+
                 #region Sword and Spear Reworks
                 case ItemID.CobaltNaginata:
                     balanceNumber = -1;

--- a/Core/ModPlayers/EModePlayer.cs
+++ b/Core/ModPlayers/EModePlayer.cs
@@ -42,6 +42,8 @@ namespace FargowiltasSouls.Core.ModPlayers
         public int CobaltHitCounter;
 
         public int LightningCounter;
+
+        public int CrossNecklaceTimer;
         private int WeaponUseTimer => Player.FargoSouls().WeaponUseTimer;
 
         public override void ResetEffects()
@@ -449,6 +451,20 @@ namespace FargowiltasSouls.Core.ModPlayers
         {
             if (!WorldSavingSystem.EternityMode)
                 return;
+
+            Main.NewText(CrossNecklaceTimer);
+            if (Player.longInvince && !Player.immune)
+            {
+                if (CrossNecklaceTimer < 60)
+                {
+                    Player.longInvince = false;
+                    CrossNecklaceTimer++;
+                }
+            }
+            else
+            {
+                CrossNecklaceTimer = 0;
+            }
 
             if (Player.iceBarrier)
                 Player.GetDamage(DamageClass.Generic) -= 0.10f;

--- a/Localization/TranslationsNeeded.txt
+++ b/Localization/TranslationsNeeded.txt
@@ -1,4 +1,4 @@
-en-US, 2535/2535, 100%, missing 0
-es-ES, 2/2535, 0%, missing 2533
-zh-Hans, 2505/2535, 99%, missing 30
-pt-BR, 1425/2535, 56%, missing 1110
+en-US, 2536/2536, 100%, missing 0
+es-ES, 2/2536, 0%, missing 2534
+zh-Hans, 2505/2536, 99%, missing 31
+pt-BR, 1425/2536, 56%, missing 1111

--- a/Localization/en-US/Mods.FargowiltasSouls.EModeBalance.hjson
+++ b/Localization/en-US/Mods.FargowiltasSouls.EModeBalance.hjson
@@ -37,4 +37,5 @@ MythrilHalberdRework: After not attacking for 2 seconds, your next attack deals 
 OrichalcumHalberdRework: Releases flower petals on swing
 SuperStarCannon: Decreased maximum pierce to 7
 WarmthPotionNerf: Halved damage reduction effect
+CrossNecklaceNerf: Longer invincibility doesn't trigger on rapid successive hits
 IceBladeFrostburn: Projectile inflicts Frostburn on-hit

--- a/Localization/es-ES/Mods.FargowiltasSouls.EModeBalance.hjson
+++ b/Localization/es-ES/Mods.FargowiltasSouls.EModeBalance.hjson
@@ -37,4 +37,5 @@
 // OrichalcumHalberdRework: Releases flower petals on swing
 // SuperStarCannon: Decreased maximum pierce to 7
 // WarmthPotionNerf: Halved damage reduction effect
+// CrossNecklaceNerf: Longer invincibility cannot trigger within 2 seconds after invincibility frames
 // IceBladeFrostburn: Projectile inflicts Frostburn on-hit

--- a/Localization/es-ES/Mods.FargowiltasSouls.Items.hjson
+++ b/Localization/es-ES/Mods.FargowiltasSouls.Items.hjson
@@ -2413,6 +2413,7 @@ MutantsDiscountCard: {
 		'''
 		Permanently reduces Mutant's shop prices by 20%
 		'It's not used how you think'
+		Minor improvements to all stats
 		''' */
 }
 
@@ -3623,7 +3624,7 @@ EaterLauncherJr: {
 	/* Tooltip:
 		'''
 		Right Click in inventory to load a Rotten Chunk for ammunition
-		Attempting to fire when out of ammunition also loads a Rotten Chunk
+		Attempting to fire also loads Rotten Chunk if necessary
 		Each Rotten Chunk provides 100 rounds, up to 1000
 		Fires a chunk of rotted flesh
 		Increased damage to enemies in the given range

--- a/Localization/pt-BR/Mods.FargowiltasSouls.EModeBalance.hjson
+++ b/Localization/pt-BR/Mods.FargowiltasSouls.EModeBalance.hjson
@@ -37,4 +37,5 @@ IceBarrier: Modo Eternidade: 10% de redução nos danos
 // OrichalcumHalberdRework: Releases flower petals on swing
 // SuperStarCannon: Decreased maximum pierce to 7
 // WarmthPotionNerf: Halved damage reduction effect
+// CrossNecklaceNerf: Longer invincibility cannot trigger within 2 seconds after invincibility frames
 // IceBladeFrostburn: Projectile inflicts Frostburn on-hit

--- a/Localization/pt-BR/Mods.FargowiltasSouls.Items.hjson
+++ b/Localization/pt-BR/Mods.FargowiltasSouls.Items.hjson
@@ -3578,7 +3578,7 @@ EaterLauncherJr: {
 	/* Tooltip:
 		'''
 		Right Click in inventory to load a Rotten Chunk for ammunition
-		Attempting to fire when out of ammunition also loads a Rotten Chunk
+		Attempting to fire also loads Rotten Chunk if necessary
 		Each Rotten Chunk provides 100 rounds, up to 1000
 		Fires a chunk of rotted flesh
 		Increased damage to enemies in the given range

--- a/Localization/zh-Hans/Mods.FargowiltasSouls.EModeBalance.hjson
+++ b/Localization/zh-Hans/Mods.FargowiltasSouls.EModeBalance.hjson
@@ -37,4 +37,5 @@ MythrilHalberdRework: 不攻击持续2秒后下一击造成三倍伤害
 OrichalcumHalberdRework: 挥舞时矛的顶端会释放花瓣
 SuperStarCannon: 最大穿透次数降低为7次
 WarmthPotionNerf: 伤害减免效果减半
+// CrossNecklaceNerf: Longer invincibility cannot trigger within 2 seconds after invincibility frames
 // IceBladeFrostburn: Projectile inflicts Frostburn on-hit


### PR DESCRIPTION
-Cross Necklace nerf: Long invincibility cannot trigger before 2 seconds after invincibility frames end (this targets specifically facetanking)